### PR TITLE
Test Deployment PR (use this PR to sample ansible scripts)

### DIFF
--- a/ansible/tasks/check_if_should_build.yaml
+++ b/ansible/tasks/check_if_should_build.yaml
@@ -35,13 +35,13 @@
     when: bc.resources|length > 0
 
     
-
   - name: Get last commit from PR {{ PR }}
     uri:
-      url: https://api.github.com/repos/bcgov/digital.gov.bc.ca/commits/refs/pull/{{ PR }}/head
+      url: https://api.github.com/repos/{{ github_owner }}/{{ github_repo }}/commits/refs/pull/{{ PR }}/head
       method: GET
     register: response
     when: bc.resources|length > 0
+    ignore_errors: true
 
   - name: Check if should build by comparing Build commit with PR Commit
     set_fact:

--- a/openshift/templates/README.md
+++ b/openshift/templates/README.md
@@ -1,12 +1,3 @@
 ## Openshift Template
 
 this houses all the infra code templates for the app
-
-
-- react-frontend
-
-the front end components
-
-- rh-container-catalog
-
-this is a pull secret we use so that we can pull rh catalog images

--- a/openshift/templates/strapi/bc.yaml
+++ b/openshift/templates/strapi/bc.yaml
@@ -46,11 +46,11 @@ objects:
     postCommit: {}
     resources: 
       requests:
-        memory: 500Mi
-        cpu: 250m
+        memory: 1Gi
+        cpu: 850m
       limits:
-        memory: 850Mi
-        cpu: 500m
+        memory: 2Gi
+        cpu: 1500m
     runPolicy: Serial
     source:
       contextDir: strapi-app

--- a/strapi-app/Dockerfile
+++ b/strapi-app/Dockerfile
@@ -32,5 +32,6 @@ RUN yarn install --network-timeout=600000
 # add app
 COPY . ./
 
+RUN strapi build
 # start app
 CMD ["yarn","start"]  

--- a/strapi-app/Dockerfile
+++ b/strapi-app/Dockerfile
@@ -32,6 +32,6 @@ RUN yarn install --network-timeout=600000
 # add app
 COPY . ./
 
-RUN strapi build
+RUN yarn build
 # start app
 CMD ["yarn","start"]  


### PR DESCRIPTION
The pr is kept open to sample the anisble scripts
> follow pre requisites as described in the `ansible/README.md`

1. build strapi `ansible-playbook build-strapi.yaml -e PR=10`
2. deploy mongo `ansible-playbook deploy-mongo.yaml -e PR=10`
> wait for mongo to be ready by viewing logs `oc logs pod/mongo-ha-pr-10-0` and look for readiness of replicas
> you will be looking for messages like `Member mongo-ha-pr-10-2.mongo-ha-pr-10-internal.<namespace>.svc.cluster.local:27017 is now in state SECONDARY` and
> `Member mongo-ha-pr-10-1.mongo-ha-pr-10-internal.va3azs-patricksimonian-ocp201-tst-dev.svc.cluster.local:27017 is now in state SECONDARY`
> when ready
3. deploy strapi `ansible-playbook deploy-strapi.yaml -e PR=10`
> when strapi is ready
4. backup restore check `ansible-playbook backup-restore-mongo.yaml -e PR=10`
> if there is no thrown errors the backup and restore was succesful


Fixes #8 